### PR TITLE
Fix monsters turning instantly

### DIFF
--- a/dlls/entities/base/CCineMonster.cpp
+++ b/dlls/entities/base/CCineMonster.cpp
@@ -377,7 +377,6 @@ void CCineMonster::PossessEntity(void)
             pTarget->pev->avelocity = Vector(0, 0, 0);
             pTarget->pev->velocity = Vector(0, 0, 0);
             pTarget->pev->effects |= EF_NOINTERP;
-            pTarget->pev->angles.y = pev->angles.y;
             pTarget->m_scriptState = SCRIPT_WAIT;
             //m_startTime = gpGlobals->time + 1E6;
             break;
@@ -386,6 +385,12 @@ void CCineMonster::PossessEntity(void)
             pTarget->m_scriptState = SCRIPT_WAIT;
             break;
         }
+
+        /* handle instant turn */
+        if (m_fMoveTo == 4 || m_fMoveTo == 6) {
+            pTarget->pev->angles.y = pev->angles.y;
+        }
+
         //        ALERT( at_aiconsole, "\"%s\" found and used (INT: %s)\n", STRING( pTarget->pev->targetname ), FBitSet(pev->spawnflags, SF_SCRIPT_NOINTERRUPT)?"No":"Yes" );
 
         pTarget->m_IdealMonsterState = MONSTERSTATE_SCRIPT;


### PR DESCRIPTION
This small hotfix should fix monsters turning instantly on regular move commands. 